### PR TITLE
User tableにwindow_idを追加

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,5 +22,3 @@ config/environments/*.local.yml
 
 /.bundle
 /vendor/bundle
-
-/gitflow

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ config/environments/*.local.yml
 
 /.bundle
 /vendor/bundle
+
+/gitflow

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -279,6 +279,3 @@ DEPENDENCIES
   twitter-bootstrap-rails
   uglifier
   unicorn
-
-BUNDLED WITH
-   1.10.6

--- a/db/migrate/20151226061745_add_windowid_to_user.rb
+++ b/db/migrate/20151226061745_add_windowid_to_user.rb
@@ -1,0 +1,5 @@
+class AddWindowidToUser < ActiveRecord::Migration
+  def change
+    add_column :users, :window_id, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20151225153553) do
+ActiveRecord::Schema.define(version: 20151226061745) do
 
   create_table "matches", force: :cascade do |t|
     t.integer  "my_id"
@@ -34,6 +34,7 @@ ActiveRecord::Schema.define(version: 20151225153553) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string   "gender"
+    t.string   "window_id"
   end
 
 end


### PR DESCRIPTION
## ユーザテーブルにwindow_idの追加。

以下の通り、window_idを追加した。
追加後もrailsが正常に動くことを確認済。

```
[3] pry(main)> User.all
  User Load (1.5ms)  SELECT "users".* FROM "users"
=> [#<User:0x007f80baf1f4e0
  id: 1,
  name: "Hiro",
  room_id: 4,
  created_at: Sun, 20 Dec 2015 07:43:58 UTC +00:00,
  updated_at: Sun, 20 Dec 2015 07:43:58 UTC +00:00,
  gender: nil,
  window_id: nil>,
```
## .gitignoreに/gitflowを追加

git-flowインストールしてinitとしたら、/gitflowディレクトリが作成された。GitHubに挙げる必要ないため、.gitignoreに追加した。
