### PR TITLE
APIv2を利用してユーザ情報を表示するように修正

### DIFF
--- a/app/assets/javascripts/connect_api.js
+++ b/app/assets/javascripts/connect_api.js
@@ -12,7 +12,6 @@ function selectElm_wGender(s_gender){
 }
 //API取得したuinfoのうち、追加されたpeer(wid)の情報を選択
 function select_uinfo(wid, resp){
-    var wid = '1' // ★暫定的
     for(var i=0; i<resp.length; i++){
 	var tmp = resp[i];
 	//console.log( wid + ' and ' + tmp.id + ' =? ' + (wid == tmp.id) );
@@ -27,40 +26,56 @@ function select_uinfo(wid, resp){
     return false;
 }
 
-function addview_uinfo(uinfo, wid){
-    //alert(uinfo['name']);
+function addview_uinfo(video, uinfo, wid){
+
+    // ユーザ枠を追加: <div id = "peer-video-uinfo-[windowid]">
+    var pVideoElem = document.createElement('div');
+    pVideoElem.setAttribute("id", 'peer-video-uinfo-'+ video['id']);
+    console.log('peer video obj:');
+    console.log(video);
+    ( $('#peer-video-uinfo-'+ video['id'])[0] )? console.log('exist_peer') : $(pVideoElem).appendTo(selectElm_wGender(uinfo['gender']));
+
+    // peerのvideoを表示
+    var vNode = MultiParty.util.createVideoNode(video);
+    vNode.setAttribute("class", "video peer-video");
+    $(vNode).appendTo(pVideoElem); 
+
+    //ユーザ情報の表示
     var nameElem = document.createElement('div');
     nameElem.setAttribute("class", "peer-name");
-    nameElem.innerHTML = "pname: " + uinfo['name'] + '<br>' + "pgender: " + uinfo['gender'];
-    $(nameElem).appendTo("#peer-video-uinfo-" + wid); //★動的に
+    nameElem.setAttribute("id", "peer-name-" + wid);
+    nameElem.innerHTML = ('pname: ' + uinfo['name'] + '<br> pgender: ' + uinfo['gender']);
+    ( $("#peer-name-" + wid)[0] )? console.log('exist_peer') : $(nameElem).appendTo("#peer-video-uinfo-" + wid);
+   
+   //    $("#peer-name-" + wid).html("pname: " + uinfo['name'] + '<br>' + "pgender: " + uinfo['gender']);
 }
 
 // ------------------------------------
 // 1. Get userinfo API
 // ------------------------------------
-function display_uinfo(wid, roomid){
-    //    var wid = '1'; //暫定★
-    // APIにアクセス
-    var api_url = '/api/v1/users/' + roomid + '.json';
-    //var api_url = '/api/v1/users/1.json'; //暫定的に
-    console.log('api connect: url=' + api_url + ',   param=' + wid );
+function display_uinfo(video, roomid){
+    var api_url = '/api/v1/window_id/' + video['id'] + '.json?room_id=' + roomid;
+    //'/api/v1/users/' + roomid + '.json';
+    console.log('api connect: url=' + api_url);
     $.ajax({
-	    type: "GET",  //★ API修正後、postにして、widパラメータにいれる
-	    url: api_url, //data: [param],
+	    type: "GET",
+	    url: api_url,
             dataType: "json",
 	    //通信成功時
 	    success: function(resp){
-		console.log('ajax json output');
-		var obj = select_uinfo(wid, resp);
-		console.log(obj['name']);
-		addview_uinfo(obj, wid);
+		//var obj = select_uinfo(wid, resp);
+		//console.log(obj['name']);
+		//addview_uinfo(obj, wid);
+		console.log('api response: url=' + api_url);
+		console.log(resp);
+		addview_uinfo(video, resp, video['id']);
 	    }
 	});
 }
 
 
 // ------------------------------------
-// 2. use Fullroom API
+// 2. Fullroom API
 // ------------------------------------
 function check_fullroom(roomid){
     // APIにアクセス
@@ -76,6 +91,25 @@ function check_fullroom(roomid){
 		console.log('result: ' + resp.result + '  from:' + api_url);
 		if (resp.result) { display_timer(); }
 		//var obj = ;
+	    }
+	});
+}
+
+// ------------------------------------
+// 3. resist windowid for userDB
+// ------------------------------------
+function regist_windowid(userid, wid){
+    // APIにアクセス
+    var api_url = '/api/v1/user/' + userid + '.json';
+    console.log('api connect: url=' + api_url + 'with wid: ' + wid);
+    $.ajax({
+	    type: "PUT",
+	    url: api_url, 
+	    data: "window_id=" + wid,
+            dataType: "json",
+	    //通信成功時
+	    success: function(resp){
+		console.log('result: ' + resp.result + '  from:' + api_url);
 	    }
 	});
 }

--- a/app/assets/javascripts/video_chat.js
+++ b/app/assets/javascripts/video_chat.js
@@ -4,48 +4,39 @@
  * ----------------------------------------------------------------- */
 
 //自分が入室したときの処理
-function proc_myms(video, s_name, s_gender){
+function proc_myms(video, s_roomid, s_name, s_gender, uid){
     console.log('myvideo obj:');
     console.log(video);
     // 3. resist wid
-    //resist_wid();
+    regist_windowid(uid, video['id']);
 
     // 自分のvideoを表示
     var vNode = MultiParty.util.createVideoNode(video);
     vNode.setAttribute("class", "video my-video");
     vNode.volume = 0;
     $(vNode).appendTo(selectElm_wGender(s_gender)); //"#streams"
+
     // 名前枠を追加
     var myVideoElem = document.createElement('div');
-    myVideoElem.setAttribute("id", 'my-video-uinfo'); //★ 動的にwid入れる
-    myVideoElem.innerHTML = 'name:  ' + s_name + '<br>gen: ' + s_gender;
+    myVideoElem.setAttribute("id", 'my-video-uinfo'); 
+    myVideoElem.innerHTML = 'myname:  ' + s_name + '<br>mygen: ' + s_gender;
     $(myVideoElem).appendTo(selectElm_wGender(s_gender)); //"#streams"
-    
 }
+
 //他人が入室したときの処理
 function peer_myms(roomid, video){
-    // ユーザ枠を追加: <div id = "peer-video-uinfo-[windowid]">
-    var pVideoElem = document.createElement('div');
-    pVideoElem.setAttribute("id", 'peer-video-uinfo-'+ video['id']);
-    console.log('peer video obj:');
-    console.log(video);
-    $(pVideoElem).appendTo(selectElm_wGender(s_gender)); //"#streams"
-
-    // peerのvideoを表示
-    var vNode = MultiParty.util.createVideoNode(video);
-    vNode.setAttribute("class", "video peer-video");
-    $(vNode).appendTo(pVideoElem); 
 
     // 1. get peer uinfo
-    display_uinfo(video['id'], roomid); // wid, roomid
+    display_uinfo(video, roomid); // wid, roomid
+
     // 2. check fullroom API
     check_fullroom(roomid); // roomid ■動的に //call display_timer();
 }
 
 
-function manage_mediasteam(s_roomid, s_name, s_gender) {
+function manage_mediasteam(s_roomid, s_name, s_gender, uid) {
     multiparty.on('my_ms', function(video) {
-	    proc_myms(video, s_name, s_gender); //自分入室時の処理
+	    proc_myms(video, s_roomid, s_name, s_gender, uid); //自分入室時の処理
 
 	}).on('peer_ms', function(video) {
 	    peer_myms(s_roomid, video); //自分入室時の処理
@@ -62,7 +53,7 @@ function manage_mediasteam(s_roomid, s_name, s_gender) {
 	});
 }
 
-function manage_message(){
+function manage_message(name){
     multiparty.on('message', function(mesg) {
 	    // peerからテキストメッセージを受信
 	    $("p.receive").append(mesg.data + "<br>");
@@ -73,6 +64,7 @@ function manage_message(){
 	    // テキストデータ取得
 	    var $text = $(this).find("input[type=text]");
 	    var data = $text.val();
+	    data = name + ': ' + data;
 	    if(data.length > 0) {
 		data = data.replace(/</g, "<").replace(/>/g, ">");
 		$("p.receive").append(data + "<br>");
@@ -84,17 +76,17 @@ function manage_message(){
 }
 
 //先に、manage_***()の定義が必要
-function video_chat_start(s_roomid, s_name, s_gender) {
+function video_chat_start(s_roomid, s_name, s_gender, uid) {
     multiparty = new MultiParty( {
 	    "key": "44ed614d-25eb-4a1f-b7a8-a47acd9f7595",
 	    "reliable": true,
 	    "room_id": s_roomid,
-	    "debug": 3
+	    "debug": 2
 	});
-    manage_message();
+    manage_message(s_name);
     // サーバとpeerに接続
     multiparty.start();
-    manage_mediasteam(s_roomid, s_name, s_gender);
+    manage_mediasteam(s_roomid, s_name, s_gender, uid);
 }
 
 // Exit機能

--- a/app/controllers/rooms_controller.rb
+++ b/app/controllers/rooms_controller.rb
@@ -26,11 +26,12 @@ class RoomsController < ApplicationController
       room_id: room.id
     )
 
-    redirect_to :action => "room", :id => user.id
+    redirect_to :action => "room", :id => room.id, :user_id => user.id
   end
 
   def room
-    gon.user = User.find(params[:id])
+    gon.user = User.find(params[:user_id])
+    gon.room_id = params[:id]
   end
 
   def vote

--- a/app/views/rooms/room.html.haml
+++ b/app/views/rooms/room.html.haml
@@ -23,6 +23,16 @@
       #exit_button
         %button{:class => 'btn btn-info btn-large', :type => "submit", :onclick => "exit_video_chat()"} Exit
 
+      /message start
+      #message
+        %form
+          %input{:type => "text"}
+          %button{:type => "submit"} send
+        %p.receive
+        /message end
+
 :javascript
   //var multyparty;
-  video_chat_start(gon.room_id, gon.user.name, gon.user.gender);
+  console.log(gon.user);
+  console.log(gon.room_id);
+  video_chat_start(gon.room_id, gon.user.name, gon.user.gender, gon.user.id);


### PR DESCRIPTION
◆修正
・APIv2(resist window_id / get user with window_id)を利用してユーザ情報を表示するように修正
・roomコントローラでのパラメータ受け渡しが誤っていたので修正

◆動作確認
・複数人で同時で入室した場合に、他ユーザ情報が適切に表示されていること
・room.hamlで受け渡す「room_id」「user」が適切であること

◆todo
・roomへのuserid受け渡し
->現状はパラメータにユーザidを含んでしまっているため、セキュリティ的にNG
 例)http://localhost:3000/room/2?user_id=5
-> "issueで検討":https://github.com/iot-social-network-link/meetalk/issues/43
