### PR TITLE
delete useless APIs

### DIFF
--- a/app/api/api.rb
+++ b/app/api/api.rb
@@ -21,12 +21,6 @@ class API < Grape::API
   end
 
   resource "users" do
-    desc "returns all users"
-    # All User Info API: http://localhost:3000/api/v1/users
-    get do
-      return User.all
-    end
-
     desc "return a user in the room"
     # Users in the room API: http://localhost:3000/api/v1/users/:room_id
     params do
@@ -52,14 +46,6 @@ class API < Grape::API
         return user
       end
     end
-  end
-
-  resource "rooms" do
-	  desc "returns all rooms"
-    # All Rooms Info API: http://localhost:3000/api/v1/rooms
-	  get do
-		  return Room.all
-	  end
   end
 
   resource "room_full" do


### PR DESCRIPTION
関連issue #30 

以下二つのAPIの削除

```
データベースに入っている全ユーザ情報を返すAPI(http://localhost:3000/api/v1/users)
データベースに入っている全ルーム情報を返すAPI(http://localhost:3000/api/v1/rooms)
```
