### PR TITLE
ユーザ退出時に、退出ユーザのステータスを無効化するAPIの実装 #12

### DIFF
--- a/app/apis/api.rb
+++ b/app/apis/api.rb
@@ -65,7 +65,7 @@ class API < Grape::API
   resource "leaving_user" do
     desc "change to invalids status with User"
     # Leaving User Full API: 
-    # $ curl -X PUT curl -X PUT http://localhost:3000/api/v1/leaving_user/:user_id -d ""
+    # $ curl -X PUT curl -X PUT http://localhost:3000/api/v1/leaving_user -d "user_id=:user_id"
     params do
       requires :user_id, type: Integer
     end
@@ -73,8 +73,7 @@ class API < Grape::API
     put do
       user = User.find_by_id(params[:user_id])
       if user.present?
-        user.update_attribute(:status, false)
-        return { result: true } if user.save
+        return { result: true } if user.update(:status => 'false')
       end
       return { result: false }
     end

--- a/app/apis/api.rb
+++ b/app/apis/api.rb
@@ -62,6 +62,24 @@ class API < Grape::API
     end
   end
 
+  resource "leaving_user" do
+    desc "change to invalids status with User"
+    # Leaving User Full API: 
+    # $ curl -X PUT curl -X PUT http://localhost:3000/api/v1/leaving_user/:user_id -d ""
+    params do
+      requires :user_id, type: Integer
+    end
+
+    put do
+      user = User.find_by_id(params[:user_id])
+      if user.present?
+        user.update_attribute(:status, false)
+        return { result: true } if user.save
+      end
+      return { result: false }
+    end
+  end
+
   resource "room_full" do
 	  desc "returns True when four member joined in the room"
     # Room Full API: http://localhost:3000/api/v1/room_full/:room_id

--- a/app/apis/api.rb
+++ b/app/apis/api.rb
@@ -65,15 +65,15 @@ class API < Grape::API
   resource "leaving_user" do
     desc "change to invalids status with User"
     # Leaving User Full API: 
-    # $ curl -X PUT curl -X PUT http://localhost:3000/api/v1/leaving_user -d "user_id=:user_id"
+    # $ curl -X PUT curl -X PUT http://localhost:3000/api/v1/leaving_user -d "window_id=:window_id"
     params do
-      requires :user_id, type: Integer
+      requires :window_id, type: String
     end
 
     put do
-      user = User.find_by_id(params[:user_id])
+      user = User.find_by(window_id: params[:window_id])
       if user.present?
-        return { result: true } if user.update(:status => 'false')
+        return { result: true } if user.update( :status => false )
       end
       return { result: false }
     end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,7 +7,7 @@ class User < ActiveRecord::Base
 	validates :status, inclusion: { in: [true, false] }
 	# validates :room_id, presence: true
 
-	after_create :update_room
+	after_save :update_room
 
 	private
 	def update_room

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ActiveRecord::Base
 
 	private
 	def update_room
-		count = User.where(room_id: self.room_id).group(:gender).count
+		count = User.where(room_id: self.room_id, status: 'true').group(:gender).count
 		self.room.male = count['male'] || 0
 		self.room.female = count['female'] || 0
 

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,7 +11,7 @@ class User < ActiveRecord::Base
 
 	private
 	def update_room
-		count = User.where(room_id: self.room_id, status: 'true').group(:gender).count
+		count = User.where(room_id: self.room_id, status: true).group(:gender).count
 		self.room.male = count['male'] || 0
 		self.room.female = count['female'] || 0
 

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -83,7 +83,7 @@ RSpec.describe 'API', type: :request do
     end
   end
 
-  describe "PUT /api/v1/user/:user_id" do
+  describe "PUT /api/v1/user/:user_id, :window_id" do
     let(:request){ put "/api/v1/user/#{user_id}.json", {window_id: 'test2'} }
 
     context "userが存在する場合" do
@@ -106,11 +106,13 @@ RSpec.describe 'API', type: :request do
     end
   end
 
-  describe "PUT /api/v1/user_id/:user_id" do
-    let(:request){ put "/api/v1/user_id/#{user_id}.json?" }
+  describe "PUT /api/v1/leaving_user, :window_id" do
+    let(:request){ put "/api/v1/leaving_user.json", {window_id: window_id} }
 
     context "userが存在する場合" do
       let(:user){ create(:room, :with_users).users.first }
+      let(:window_id){ user.window_id }
+      before(:each){ user.update(window_id: 'test2') }
 
       it_behaves_like 'check http_status'
       it_behaves_like 'return true'
@@ -120,15 +122,26 @@ RSpec.describe 'API', type: :request do
         expect(user.status).to eq be_falsey
       end
 
-      it "roomの人数が変更されること" do
-        request
-        expect(room.male).to eq 0
-        expect(room.female).to eq 0
+      context "user statusがtrueの場合" do
+        it "roomの人数が変更されること" do
+          request
+          expect(room.male).to eq 0
+          expect(room.female).to eq 0
+        end
+      end
+
+      context "user statusがfalseの場合" do
+        it "roomの人数が変更されないこと" do
+          user.update(status: false)
+          request
+          expect(room.male).to eq 1
+          expect(room.female).to eq 0
+        end
       end
     end
 
     context "userが存在しない場合" do
-      let(:user_id){ 99 }
+      let(:window_id){ 'test2' }
       it_behaves_like 'check http_status'
       it_behaves_like 'return false'
     end

--- a/spec/requests/api_spec.rb
+++ b/spec/requests/api_spec.rb
@@ -106,6 +106,34 @@ RSpec.describe 'API', type: :request do
     end
   end
 
+  describe "PUT /api/v1/user_id/:user_id" do
+    let(:request){ put "/api/v1/user_id/#{user_id}.json?" }
+
+    context "userが存在する場合" do
+      let(:user){ create(:room, :with_users).users.first }
+
+      it_behaves_like 'check http_status'
+      it_behaves_like 'return true'
+
+      it "user statusがfalseに変更されること" do
+        request
+        expect(user.status).to eq be_falsey
+      end
+
+      it "roomの人数が変更されること" do
+        request
+        expect(room.male).to eq 0
+        expect(room.female).to eq 0
+      end
+    end
+
+    context "userが存在しない場合" do
+      let(:user_id){ 99 }
+      it_behaves_like 'check http_status'
+      it_behaves_like 'return false'
+    end
+  end
+
   describe "DELETE /api/v1/window_id/:window_id?room_id=:room_id" do
     let(:request){ delete "/api/v1/window_id/#{window_id}.json?room_id=#{room_id}" }
 


### PR DESCRIPTION
- 仕組み
1. ユーザが退出した時に、各ユーザはサーバに退出ユーザを伝える。（javascriptでAPIを叩く）
2. 退出ユーザのstatusをtrue→falseに変更する。
3. roomのmale,female の再カウントを実行し、ルーム内の人数を更新する。

APIにPUTする際のコマンドは、
curl -X PUT curl -X PUT http://localhost:3000/api/v1/leaving_user -d "user_id=:user_id"
としている
